### PR TITLE
Support method chaining for transient context

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,24 @@ Hanami.logger.info "Request accepted"
 
 ### Transient contexts
 
-This context logger also provides a method `with_context` to add transient contexts in a block
+This context logger also provides a method `with_context` to add transient contexts. You can use a block, where the context will be applied to only in the block
 ```
 logger = HanamiContextLogging::Logger.new
 
 logger.with_context(controller: self.class, user_id: user.id) do
   logger.info "Error during user update"
 end
+# => "[controller=UserUpdate] [user_id=user123] Error during user update"
+
+logger.info "Should have no context here"
+# => "Should have no context here"
+```
+
+or the syntatic-sugar method chain, where you can method-chain with your usual logger methods (info, error, etc)
+```
+logger = HanamiContextLogging::Logger.new
+
+logger.with_context(controller: self.class, user_id: user.id).info "Error during user update"
 # => "[controller=UserUpdate] [user_id=user123] Error during user update"
 
 logger.info "Should have no context here"

--- a/hanami-context-logging.gemspec
+++ b/hanami-context-logging.gemspec
@@ -12,7 +12,14 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
   spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
 
-  spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
+  # to allow pushing to a single host or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata["allowed_push_host"] = "https://rubygems.org"
+  else
+    raise "RubyGems 2.0 or newer is required to protect against " \
+      "public gem pushes."
+  end
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.

--- a/lib/hanami_context_logging.rb
+++ b/lib/hanami_context_logging.rb
@@ -1,1 +1,2 @@
 require_relative "hanami_context_logging/logger"
+require_relative "hanami_context_logging/utils/benchmarking"

--- a/lib/hanami_context_logging/version.rb
+++ b/lib/hanami_context_logging/version.rb
@@ -1,3 +1,3 @@
 module HanamiContextLogging
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
# Why is this needed
I want to achieve a better-readability syntax that looks like
```
logger.with_context(random: 'context').info "new message"
```


# How was this done
- Make the method return a modified version of `self` by reinitializing and adding the transient context using `instance_eval`. This `self` will then be dereferenced right after used, so it should be garbage collected properly

# Things to note
- Checked memory used (was just thinking how much it'll be used since I keep spawning new logger every time `with_context` is called): using
```
    def print_memory_usage
      memory_before = `ps -o rss= -p #{Process.pid}`.to_i
      yield
      memory_after = `ps -o rss= -p #{Process.pid}`.to_i

      puts "Memory: #{((memory_after - memory_before) / 1024.0).round(2)} MB"
    end
```
helper method, and comparing these 3 method calls:
```
logger.info "some log message"
logger.with_context(temporary: 'context') { logger.info "block message" }
logger.with_context(temporary: 'context').info "pretty message"
```
logging 100 times in a loop, 
- the first one took about ~0.04MB at first while going down to 0.0MB after repeated 100 times loop.
- second one had about the same ~0.04 MB and going down to 0.0MB trend, although some spikes to ~0.08 was seen
- third one was about the same, but with spikes up to 0.11MB sometimes

all three averages down to very close to 0.0MB (the spikes was about once every 10 times), so I think it's not a big problem.
