### PR TITLE
Remove usage of git ls command

### DIFF
--- a/hanami-context-logging.gemspec
+++ b/hanami-context-logging.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   end
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    Dir.glob('**/*').select { |f| File.file?(f) && !f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/LOYAL-11657

When accessing console in k8s, we will often see the following error message:
```
fatal: Not a git repository (or any of the parent directories): .git
```

This error message is due to the code is attempt to access to the git command in a non-git repository. Why is this happening? Because in k8s env we no longer have git pre-installed, and several in-house gems uses the git ls-files command unnecessary.

This PR is to  fix it for the `hanami-context-logging` shared gem.


# Solution

Update/Fix the following repository

https://github.com/Kaligo/sidekiq-transaction-defender/blob/main/sidekiq-transaction-defender.gemspec

https://github.com/Kaligo/oculus/blob/master/oculus.gemspec

https://github.com/Kaligo/json-logic-ruby/blob/master/json_logic.gemspec

https://github.com/Kaligo/hanami-context-logging/blob/master/hanami-context-logging.gemspec

Refer to https://github.com/Kaligo/shared/pull/126 