### PR TITLE
Extend hanami_context_logging to handle non-hash ContextProvider#context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    hanami-context-logging (0.1.1)
+    hanami-context-logging (0.1.2)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -41,35 +41,67 @@ Or install it yourself as:
 ## Usage
 
 ### About context_provider
-context_provider is simply any object that responds to `#context` which returns a hash. The below are all valid context providers
+context_provider is simply any object that responds to `#context` which returns a hash OR is convertible to a hash via #to_h. The below are all valid context providers
 
 **Struct**
 ```
 ContextProviderStruct = Struct.new(:context)
 provider = ContextProviderStruct.new(a_context: 'a_value')
-provider.context # returns context, all good
+provider.context # returns hash, all good
 ```
 
 **Class**
 ```
+# is a hash
 class ContextProviderClass
   def self.context
     { a_context: 'a_value' }
   end
 end
 provider = ContextProviderClass
-provider.context # returns context, all good
+provider.context # returns hash, all good
+
+# can be converted to hash via to_h
+class Context
+  def to_h
+    { a_context: 'a_value' }
+  end
+end
+
+class ContextProviderClass
+  def self.context
+    Context.new
+  end
+end
+provider = ContextProviderClass
+provider.context.to_h # convertible to hash, all good
 ```
 
 **Object**
 ```
+# is a hash
 class ContextProviderClass
   def context
+   { a_context: 'a_value' }
+  end
+ end
+ provider = ContextProviderClass.new
+ provider.context # returns hash, all good
+
+# can be converted to hash via to_h
+class Context
+  def to_h
     { a_context: 'a_value' }
   end
 end
-provider = ContextProviderClass.new
-provider.context # returns context, all good
+
+class ContextProviderClass
+  def self.context
+    Context.new
+  end
+end
+provider = ContextProviderClass
+provider.context.to_h # convertible to hash, all good
 ```
 
 The logger allows you to define your own context provider. A use case for context provider is when the context is not yet known during initialization, but will be known during logging. For example

--- a/lib/hanami_context_logging/formatter/with_context.rb
+++ b/lib/hanami_context_logging/formatter/with_context.rb
@@ -17,8 +17,13 @@ module ContextLogger
     end
 
     def contexts
+      provider_context = if @context_provider.context.is_a?(Hash)
+                           @context_provider.context
+                         else
+                           @context_provider.context.to_h
+                         end
       {}.merge(
-        @context_provider.context,
+        provider_context,
         @ad_hoc_context
       )
     end

--- a/lib/hanami_context_logging/formatter/with_context_json.rb
+++ b/lib/hanami_context_logging/formatter/with_context_json.rb
@@ -18,8 +18,13 @@ class WithContextJson < Hanami::Logger::Formatter
   end
 
   def contexts
+    provider_context = if @context_provider.context.is_a?(Hash)
+                         @context_provider.context
+                       else
+                         @context_provider.context.to_h
+                       end
     {}.merge(
-      @context_provider.context,
+      provider_context,
       @ad_hoc_context
     )
   end

--- a/lib/hanami_context_logging/logger.rb
+++ b/lib/hanami_context_logging/logger.rb
@@ -7,7 +7,8 @@ module HanamiContextLogging
   class Logger < Hanami::Logger
     # A logger that has the same interface as Hanami::Logger, except
     # ContextLogger accepts one more option, called :context_provider
-    # context_provider is just any object that responds to #context which returns a hash
+    # context_provider is just any object that responds to #context which returns a hash,
+    # OR returns an object that can be converted to hash via to_h
     #
     # We first need to extract this option, otherwise Hanami::Logger cannot be initialized due to unrecognized option
     # and pad the formatter to be :with_context by default

--- a/lib/hanami_context_logging/version.rb
+++ b/lib/hanami_context_logging/version.rb
@@ -1,3 +1,3 @@
 module HanamiContextLogging
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/hanami_context_logging/logger_spec.rb
+++ b/spec/hanami_context_logging/logger_spec.rb
@@ -16,6 +16,24 @@ RSpec.describe HanamiContextLogging::Logger do
       stream.rewind
       expect(stream.read).to include('any_key_1=any_value_1', 'any_key_2=any_value_2', 'random message')
     end
+
+    context 'when context_provider#context is an object that responds to #to_h' do
+      let(:mock_context) do
+        double(to_h:
+          {
+            any_key_1: 'any_value_1',
+            any_key_2: 'any_value_2'
+          }
+        )
+      end
+
+      it 'logs message including the context given from provider' do
+        logger.info 'random message'
+
+        stream.rewind
+        expect(stream.read).to include('any_key_1=any_value_1', 'any_key_2=any_value_2', 'random message')
+      end
+    end
   end
 
   describe 'with with_context_json formatter' do
@@ -25,6 +43,24 @@ RSpec.describe HanamiContextLogging::Logger do
 
       stream.rewind
       expect(JSON.parse(stream.read)).to include('any_key_1' => 'any_value_1', 'any_key_2' => 'any_value_2', 'message' => 'random message')
+    end
+
+    context 'when context_provider#context is an object that responds to #to_h' do
+      let(:mock_context) do
+        double(to_h:
+          {
+            any_key_1: 'any_value_1',
+            any_key_2: 'any_value_2'
+          }
+        )
+      end
+
+      it 'logs message including the context given from provider' do
+        logger.info 'random message'
+
+        stream.rewind
+        expect(JSON.parse(stream.read)).to include('any_key_1' => 'any_value_1', 'any_key_2' => 'any_value_2', 'message' => 'random message')
+      end
     end
   end
 


### PR DESCRIPTION
But this at least it has to be convertible to hash via `#to_h`

This is so that we can be compatible with Oculus 0.2.1, which changed the Context from actual ruby hash to be an object (with more capabilities) -- see https://github.com/Kaligo/oculus/pull/3/files#diff-3eb728766f4a509971570cab11b09e56c1ae9c480dad013ecd314fa80ba321d6L10